### PR TITLE
Fix Vulnerabilities

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,9 @@
 source 'https://rubygems.org'
 
-gem 'jekyll', '3.8.4'
+gem 'jekyll', '~> 4.2.0'
 
 group :jekyll_plugins do
-  gem 'jekyll-feed', '0.11.0'
-  gem 'jekyll-seo-tag', '2.5.0'
-  gem 'jekyll-sitemap', '1.2.0'
+  gem 'jekyll-feed'
+  gem 'jekyll-seo-tag'
+  gem 'jekyll-sitemap'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.5.2)
-      public_suffix (>= 2.0.2, < 4.0)
+    addressable (2.8.0)
+      public_suffix (>= 2.0.2, < 5.0)
     colorator (1.1.0)
     concurrent-ruby (1.0.5)
     em-websocket (0.5.1)
@@ -14,7 +14,7 @@ GEM
     http_parser.rb (0.6.0)
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
-    jekyll (3.8.4)
+    jekyll (4.2.2)
       addressable (~> 2.4)
       colorator (~> 1.0)
       em-websocket (~> 0.5)
@@ -27,17 +27,17 @@ GEM
       pathutil (~> 0.9)
       rouge (>= 1.7, < 4)
       safe_yaml (~> 1.0)
-    jekyll-feed (0.11.0)
+    jekyll-feed (0.16.0)
       jekyll (~> 3.3)
-    jekyll-sass-converter (1.5.2)
+    jekyll-sass-converter (2.2.0)
       sass (~> 3.4)
-    jekyll-seo-tag (2.5.0)
+    jekyll-seo-tag (2.8.0)
       jekyll (~> 3.3)
-    jekyll-sitemap (1.2.0)
+    jekyll-sitemap (1.4.0)
       jekyll (~> 3.3)
-    jekyll-watch (2.0.0)
+    jekyll-watch (2.2.1)
       listen (~> 3.0)
-    kramdown (1.17.0)
+    kramdown (2.4.0)
     liquid (4.0.0)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
@@ -46,14 +46,14 @@ GEM
     mercenary (0.3.6)
     pathutil (0.16.1)
       forwardable-extended (~> 2.6)
-    public_suffix (3.0.3)
+    public_suffix (4.0.7)
     rb-fsevent (0.10.3)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
     rouge (3.3.0)
     ruby_dep (1.5.0)
     safe_yaml (1.0.4)
-    sass (3.6.0)
+    sass (3.6.5)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
       rb-fsevent (~> 0.9, >= 0.9.4)
@@ -63,10 +63,10 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  jekyll (= 3.8.4)
-  jekyll-feed (= 0.11.0)
-  jekyll-seo-tag (= 2.5.0)
-  jekyll-sitemap (= 1.2.0)
+  jekyll (= 4.2.2)
+  jekyll-feed (= 0.16.0)
+  jekyll-seo-tag (= 2.8.0)
+  jekyll-sitemap (= 1.4.0)
 
 BUNDLED WITH
-   1.16.4
+   2.3.13


### PR DESCRIPTION
Kramdown versions 2.3.1 and lower have a vulnerability ranked at 9.8 severity. By manually updating the versions, the vulnerability is patched and any risk for the user is removed. General updates to the versions are also helpful for the developer/user experience.